### PR TITLE
feat(BUX-000): add config for string port checking in dev

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,6 +35,7 @@ export default defineConfig({
   server: {
     port: 3002,
     host: true,
+    strictPort: true,
     proxy: {
       '/api': {
         target: 'http://127.0.0.1:8080',


### PR DESCRIPTION
Right now we don't have checks for port number, when starting vite locally for dev environment.

Since we are relying on proxy and API forwarding it is crucial to have the default 3002 port set and running.

After using this config, whenever the port will be already used, vite server won't start showing error.